### PR TITLE
[MM-16849] Introduce tests for Jenkins plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/stretchr/testify v1.3.0
 	github.com/waseem18/gojenkins v0.2.1-0.20190413102934-c264e08c78c3
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/zap v1.10.0 // indirect

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/plugin/plugintest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetJob(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusOK)
+	}))
+	assert.NotNil(t, testServer)
+	defer func() { testServer.Close() }()
+
+	p := &Plugin{}
+	api := &plugintest.API{}
+	p.SetAPI(api)
+
+	userInfo := &JenkinsUserInfo{
+		UserID:   "user1",
+		Username: "username1",
+		Token:    "i1BmOxqUYk_6MtXJNTUtJIQbH2VikZkGPPycfIJhAaY=",
+	}
+
+	kvData, err := json.Marshal(userInfo)
+	assert.Nil(t, err)
+
+	api.On("KVGet", "user1"+jenkinsTokenKey).Return(kvData, nil)
+
+	conf := &configuration{
+		JenkinsURL:    testServer.URL,
+		EncryptionKey: "enckeyenckeyenckeyenckey",
+	}
+	serverConf := &model.Config{}
+	p.setConfiguration(conf, serverConf)
+
+	c, err := p.getJenkinsClient("user1")
+	assert.Nil(t, err)
+	assert.NotNil(t, c)
+
+	j, err := p.getJob("user1", "job1")
+	assert.Nil(t, err)
+	assert.NotNil(t, j)
+	assert.Equal(t, "/job/job1", j.Base)
+}

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -16,7 +16,7 @@ func TestGetJob(t *testing.T) {
 		res.WriteHeader(http.StatusOK)
 	}))
 	assert.NotNil(t, testServer)
-	defer func() { testServer.Close() }()
+	defer testServer.Close()
 
 	p := &Plugin{}
 	api := &plugintest.API{}

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseBuildParameters(t *testing.T) {
+	type ExpectedResponse struct {
+		JobName     string
+		BuildNumber string
+		Valid       bool
+	}
+
+	for name, tc := range map[string]struct {
+		Input    []string
+		Expected ExpectedResponse
+	}{
+		"job name": {
+			Input:    []string{"jobname"},
+			Expected: ExpectedResponse{"jobname", "", true},
+		},
+		"job name with folder": {
+			Input:    []string{"folder/jobname"},
+			Expected: ExpectedResponse{"folder/jobname", "", true},
+		},
+		"with build number": {
+			Input:    []string{"jobname", "22"},
+			Expected: ExpectedResponse{"jobname", "22", true},
+		},
+		"with build number and folder": {
+			Input:    []string{"folder/jobname", "22"},
+			Expected: ExpectedResponse{"folder/jobname", "22", true},
+		},
+		"with quotes": {
+			Input:    []string{`"jobname"`},
+			Expected: ExpectedResponse{"jobname", "", true},
+		},
+		"with quotes and folder": {
+			Input:    []string{`"folder/jobname"`, ""},
+			Expected: ExpectedResponse{"folder/jobname", "", true},
+		},
+		"with quotes and build number": {
+			Input:    []string{`"jobname"`, "22"},
+			Expected: ExpectedResponse{"jobname", "22", true},
+		},
+		"with quotes, build number and folder": {
+			Input:    []string{`"folder/jobname"`, "22"},
+			Expected: ExpectedResponse{"folder/jobname", "22", true},
+		},
+		"with spaces": {
+			Input:    []string{`"jobname`, `with`, `spaces"`},
+			Expected: ExpectedResponse{"jobname with spaces", "", true},
+		},
+		"with spaces and folder": {
+			Input:    []string{`"folder`, "with", "spaces/and", `job"`},
+			Expected: ExpectedResponse{"folder with spaces/and job", "", true},
+		},
+		"with spaces and build number": {
+			Input:    []string{`"jobname`, `with`, `spaces"`, "22"},
+			Expected: ExpectedResponse{"jobname with spaces", "22", true},
+		},
+		"with spaces, folder, and build number": {
+			Input:    []string{`"folder`, "with", "spaces/and", `job"`, "22"},
+			Expected: ExpectedResponse{"folder with spaces/and job", "22", true},
+		},
+		"no args": {
+			Input:    []string{},
+			Expected: ExpectedResponse{"", "", false},
+		},
+		"too many args": {
+			Input:    []string{"jobname", "22", "extra-data"},
+			Expected: ExpectedResponse{"", "", false},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			job, buildNo, valid := parseBuildParameters(tc.Input)
+			assert.Equal(t, tc.Expected.JobName, job)
+			assert.Equal(t, tc.Expected.BuildNumber, buildNo)
+			assert.Equal(t, tc.Expected.Valid, valid)
+		})
+	}
+}


### PR DESCRIPTION
#### Summary

This PR introduces some tests for the Jenkins plugin. It tests the parsing of params for the `/build` slash command, and a does a smoke test of `p.getJob()`.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-16849