### PR TITLE
remove bot account creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ This plugin enables you to interact with jobs via slash commands in Mattermost. 
     1. Download the latest version of the plugin from the GitHub releases page
     2. In Mattermost, go to **System Console -> Plugins -> Management**
     3. Upload the plugin
-2. Enter Jenkins server URL
+1. Enter Jenkins server URL
     1. Go to the **System Console -> Plugins -> Jenkins**
     2. Set the Jenkins server URL along with the protocol. Example: http://jenkins.example.com, https://jenkins.example.com
     3. Save the settings
-4. Generate an at rest encryption key
+1. Generate an at rest encryption key
     1. Go to the **System Console -> Plugins -> Jenkins** and click "Regenerate" under "At Rest Encryption Key"
     2. Save the settings
-5. Enable the plugin
+1. Enable the plugin
     1. Go to System Console -> Plugins -> Management and click "Enable" underneath the Jenkins plugin
-6. Test it out
+1. Test it out
     1. In Mattermost, run the slash command `/jenkins connect <Jenkins Username> <Jenkins API Token>`
 
 ### Development

--- a/README.md
+++ b/README.md
@@ -64,10 +64,6 @@ This plugin enables you to interact with jobs via slash commands in Mattermost. 
     1. Go to the **System Console -> Plugins -> Jenkins**
     2. Set the Jenkins server URL along with the protocol. Example: http://jenkins.example.com, https://jenkins.example.com
     3. Save the settings
-3. Configure a bot account
-    1. Create a new Mattermost user, through the regular UI or the CLI with the username "Jenkins"
-    2. Go to the **System Console -> Plugins -> Jenkins** and select this user in the User setting
-    3. Save the settings
 4. Generate an at rest encryption key
     1. Go to the **System Console -> Plugins -> Jenkins** and click "Regenerate" under "At Rest Encryption Key"
     2. Save the settings


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
I don't see an option to set bot account anymore. Is the bot account now automatically created?

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

