### PR TITLE
Normalize plugin name

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "jenkins",
-    "name": "Jenkins plugin",
+    "name": "Jenkins",
     "description": "Jenkins plugin for Mattermost",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-jenkins",
     "support_url": "https://github.com/mattermost/mattermost-plugin-jenkins/issues",


### PR DESCRIPTION
#### Summary
The plugin name should not contain `plugin` as it's already clear from the context that it's a plugin.

See also https://github.com/mattermost/mattermost-plugin-todo/pull/79

#### Ticket Link
Follow up on https://github.com/mattermost/mattermost-marketplace/issues/72#issuecomment-641934376