### PR TITLE
Help displayed on invalid jenkins slash command

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -315,7 +315,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 			return p.getCommandResponse(args, "Encountered an error while creating the job"), nil
 		}
 	default:
-		text := "###### Mattermost Jenkins Plugin - Slash Command Help\n" + strings.Replace(helpText, "|", "`", -1)
+		text := "###### Unknown Command: " + action + "\n\n" + "###### Mattermost Jenkins Plugin - Slash Command Help\n" + strings.Replace(helpText, "|", "`", -1)
 		return p.getCommandResponse(args, text), nil
 	}
 	return &model.CommandResponse{}, nil

--- a/server/command.go
+++ b/server/command.go
@@ -315,7 +315,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 			return p.getCommandResponse(args, "Encountered an error while creating the job"), nil
 		}
 	default:
-		text := "###### Unknown Command: " + action + "\n\n" + "###### Mattermost Jenkins Plugin - Slash Command Help\n" + strings.Replace(helpText, "|", "`", -1)
+		text := "###### Unknown Command: " + action + "\n" + "###### Mattermost Jenkins Plugin - Slash Command Help\n" + strings.Replace(helpText, "|", "`", -1)
 		return p.getCommandResponse(args, text), nil
 	}
 	return &model.CommandResponse{}, nil

--- a/server/command.go
+++ b/server/command.go
@@ -314,6 +314,9 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 			p.API.LogError("Error while creating the job.", err.Error())
 			return p.getCommandResponse(args, "Encountered an error while creating the job"), nil
 		}
+	default:
+		text := "###### Mattermost Jenkins Plugin - Slash Command Help\n" + strings.Replace(helpText, "|", "`", -1)
+		return p.getCommandResponse(args, text), nil
 	}
 	return &model.CommandResponse{}, nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
On invalid jenkins slash command (for eg. `/jenkins run test2` as run is not a command), help is displayed to the user.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.


Otherwise, link the JIRA ticket.
-->
  Fixes https://github.com/mattermost/mattermost-plugin-jenkins/issues/37

