### PR TITLE
Add direct Jenkins build triggering without UI parameter configuration

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -628,7 +628,7 @@ func (p *Plugin) sendJobCreateRequest(userID, channelID string, parameters map[s
 		return errors.Wrap(jenkinsErr, "Error creating Jenkins client")
 	}
 
-	jobName, extraParam, ok := parseBuildParameters(strings.Split(jobName, " "))
+	jobName, extraParam, _, ok := parseBuildParameters(strings.Split(jobName, " "))
 	if !ok || extraParam != "" {
 		p.createEphemeralPost(userID, channelID, "Please check `/jenkins help` to find help on how to create a job.")
 		return errors.New("error while creating the job")

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -10,6 +10,7 @@ func TestParseBuildParameters(t *testing.T) {
 	type ExpectedResponse struct {
 		JobName     string
 		BuildNumber string
+		ExtraParams map[string]string
 		Valid       bool
 	}
 
@@ -19,65 +20,74 @@ func TestParseBuildParameters(t *testing.T) {
 	}{
 		"job name": {
 			Input:    []string{"jobname"},
-			Expected: ExpectedResponse{"jobname", "", true},
+			Expected: ExpectedResponse{"jobname", "", nil, true},
 		},
 		"job name with folder": {
 			Input:    []string{"folder/jobname"},
-			Expected: ExpectedResponse{"folder/jobname", "", true},
+			Expected: ExpectedResponse{"folder/jobname", "", nil, true},
 		},
 		"with build number": {
 			Input:    []string{"jobname", "22"},
-			Expected: ExpectedResponse{"jobname", "22", true},
+			Expected: ExpectedResponse{"jobname", "22", nil, true},
 		},
 		"with build number and folder": {
 			Input:    []string{"folder/jobname", "22"},
-			Expected: ExpectedResponse{"folder/jobname", "22", true},
+			Expected: ExpectedResponse{"folder/jobname", "22", nil, true},
 		},
 		"with quotes": {
 			Input:    []string{`"jobname"`},
-			Expected: ExpectedResponse{"jobname", "", true},
+			Expected: ExpectedResponse{"jobname", "", nil, true},
 		},
 		"with quotes and folder": {
 			Input:    []string{`"folder/jobname"`, ""},
-			Expected: ExpectedResponse{"folder/jobname", "", true},
+			Expected: ExpectedResponse{"folder/jobname", "", nil, true},
 		},
 		"with quotes and build number": {
 			Input:    []string{`"jobname"`, "22"},
-			Expected: ExpectedResponse{"jobname", "22", true},
+			Expected: ExpectedResponse{"jobname", "22", nil, true},
 		},
 		"with quotes, build number and folder": {
 			Input:    []string{`"folder/jobname"`, "22"},
-			Expected: ExpectedResponse{"folder/jobname", "22", true},
+			Expected: ExpectedResponse{"folder/jobname", "22", nil, true},
 		},
 		"with spaces": {
 			Input:    []string{`"jobname`, `with`, `spaces"`},
-			Expected: ExpectedResponse{"jobname with spaces", "", true},
+			Expected: ExpectedResponse{"jobname with spaces", "", nil, true},
 		},
 		"with spaces and folder": {
 			Input:    []string{`"folder`, "with", "spaces/and", `job"`},
-			Expected: ExpectedResponse{"folder with spaces/and job", "", true},
+			Expected: ExpectedResponse{"folder with spaces/and job", "", nil, true},
 		},
 		"with spaces and build number": {
 			Input:    []string{`"jobname`, `with`, `spaces"`, "22"},
-			Expected: ExpectedResponse{"jobname with spaces", "22", true},
+			Expected: ExpectedResponse{"jobname with spaces", "22", nil, true},
 		},
 		"with spaces, folder, and build number": {
 			Input:    []string{`"folder`, "with", "spaces/and", `job"`, "22"},
-			Expected: ExpectedResponse{"folder with spaces/and job", "22", true},
+			Expected: ExpectedResponse{"folder with spaces/and job", "22", nil, true},
 		},
 		"no args": {
 			Input:    []string{},
-			Expected: ExpectedResponse{"", "", false},
+			Expected: ExpectedResponse{"", "", nil, false},
 		},
-		"too many args": {
+		"with not well structured parameters": {
 			Input:    []string{"jobname", "22", "extra-data"},
-			Expected: ExpectedResponse{"", "", false},
+			Expected: ExpectedResponse{"jobname", "22", nil, true},
+		},
+		"with well structured parameters": {
+			Input:    []string{"jobname", "22", "param1=value1", "param2=value2"},
+			Expected: ExpectedResponse{"jobname", "22", map[string]string{"param1": "value1", "param2": "value2"}, true},
+		},
+		"with well structured parameters and no build number": {
+			Input:    []string{"jobname", "param1=value1", "param2=value2"},
+			Expected: ExpectedResponse{"jobname", "", map[string]string{"param1": "value1", "param2": "value2"}, true},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			job, buildNo, valid := parseBuildParameters(tc.Input)
+			job, buildNo, extraParams, valid := parseBuildParameters(tc.Input)
 			assert.Equal(t, tc.Expected.JobName, job)
 			assert.Equal(t, tc.Expected.BuildNumber, buildNo)
+			assert.Equal(t, tc.Expected.ExtraParams, extraParams)
 			assert.Equal(t, tc.Expected.Valid, valid)
 		})
 	}


### PR DESCRIPTION
This PR implements direct build triggering from Mattermost without requiring users to set build parameters in the UI.

Fixes issue: https://github.com/mattermost-community/mattermost-plugin-jenkins/issues/25

## Changes
- Added functionality to directly trigger Jenkins builds from Mattermost
- Eliminated the need for manual parameter configuration in the UI

## Testing
I've tested this with the build command functionality, as that's our primary use case. 

## Notes
As I'm not fluent in Golang, I welcome any suggestions or feedback for improvements.

Thank you for maintaining this plugin.
